### PR TITLE
Add VK TURN Proxy app

### DIFF
--- a/docs/_apps/vk-turn-proxy.md
+++ b/docs/_apps/vk-turn-proxy.md
@@ -2,7 +2,7 @@
 name: vk-turn-proxy
 title: VK TURN Proxy
 description: "Server-side TURN-based proxy for tunneling traffic through VK calls."
-category: Networking
+category: Networking & Proxy
 version: 1.8.2
 architectures:
   - amd64

--- a/docs/_apps/vk-turn-proxy.md
+++ b/docs/_apps/vk-turn-proxy.md
@@ -1,0 +1,50 @@
+---
+name: vk-turn-proxy
+title: VK TURN Proxy
+description: "Server-side TURN-based proxy for tunneling traffic through VK calls."
+category: Networking
+version: 1.8.2
+architectures:
+  - amd64
+  - aarch64
+ports:
+  - 56000
+faq:
+  - q: "What should I put into connect_addr?"
+    a: "Set the backend target as host:port, for example 127.0.0.1:51820 for a local WireGuard instance."
+  - q: "What is vless_mode?"
+    a: "Enable it only when you want the proxy to forward TCP/VLESS-style traffic instead of the default UDP/WireGuard-style mode."
+---
+
+# VK TURN Proxy
+
+Server-side wrapper for [`vk-turn-proxy`](https://github.com/cacggghp/vk-turn-proxy) packaged for the `home-assistant-apps` repository.
+
+## About
+
+This app exposes UDP port `56000` and forwards incoming traffic to a configured backend address. It is intended for advanced networking scenarios using the upstream `vk-turn-proxy` project.
+
+## Configuration
+
+### connect_addr
+Required backend target in `host:port` form.
+
+Examples:
+- `127.0.0.1:51820`
+- `192.168.1.10:51820`
+
+### vless_mode
+Optional boolean flag to enable VLESS-style forwarding mode.
+
+## Port
+
+- `56000/udp`
+
+## Upstream
+
+- [Repository](https://github.com/cacggghp/vk-turn-proxy)
+- [Container package](https://github.com/cacggghp/vk-turn-proxy/pkgs/container/vk-turn-proxy)
+
+---
+
+[← Back to Apps](/apps/) | [View on GitHub](https://github.com/j0rsa/home-assistant-apps/tree/main/vk-turn-proxy)

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -43,6 +43,11 @@ High-performance vector database for AI applications. Essential for semantic sea
 
 **Version:** 1.0.14 | **Architectures:** `amd64`, `aarch64`
 
+### [Wyoming Hailo Whisper](/apps/wyoming-hailo-whisper/)
+Local Whisper STT over Wyoming using Hailo acceleration on Raspberry Pi 5.
+
+**Version:** 0.0.2 | **Architectures:** `aarch64`
+
 ---
 
 ## 🌐 Networking & Proxy
@@ -81,6 +86,11 @@ Transparent SOCKS5 proxy client that intercepts TCP/UDP traffic and forwards it 
 SNI proxy with SOCKS5 proxy support. Routes HTTP and HTTPS traffic through a SOCKS5 proxy based on hostname matching.
 
 **Version:** 1.0.0 | **Architectures:** `amd64`, `aarch64`
+
+### [VK TURN Proxy](/apps/vk-turn-proxy/)
+Server-side TURN-based proxy for tunneling traffic through VK calls.
+
+**Version:** 1.8.2 | **Architectures:** `amd64`, `aarch64`
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,6 +97,15 @@ High-performance vector database for AI applications. Essential for semantic sea
 
 **Architectures:** `aarch64` `amd64`
 
+#### [Wyoming Hailo Whisper](/apps/wyoming-hailo-whisper/)
+Local Wyoming STT app using Whisper accelerated by Hailo on Raspberry Pi 5.
+- Whisper STT over Wyoming
+- Hailo-8 / Hailo-8L support
+- Home Assistant voice pipeline friendly
+- Persistent model/runtime storage in `/share`
+
+**Architectures:** `aarch64`
+
 ---
 
 ### 🌐 Networking & Proxy
@@ -179,6 +188,15 @@ Transparent SOCKS5 proxy client that intercepts TCP/UDP traffic and forwards it 
 - DNS request forwarding
 - Low-level traffic interception
 - Works with [Go SOCKS5 Proxy](/apps/go-socks5-proxy/)
+
+**Architectures:** `aarch64` `amd64`
+
+#### [VK TURN Proxy](/apps/vk-turn-proxy/)
+Server-side wrapper for vk-turn-proxy packaged for Home Assistant.
+- UDP port 56000 exposure
+- Configurable backend target
+- Optional VLESS mode
+- Suitable for advanced networking scenarios
 
 **Architectures:** `aarch64` `amd64`
 

--- a/vk-turn-proxy/Dockerfile
+++ b/vk-turn-proxy/Dockerfile
@@ -1,0 +1,34 @@
+ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base-ubuntu:24.04
+ARG UPSTREAM_IMAGE=ghcr.io/cacggghp/vk-turn-proxy:v1.8.2
+
+FROM ${UPSTREAM_IMAGE} AS upstream
+FROM ${BUILD_FROM}
+
+ARG BUILD_VERSION
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_REF
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates tzdata \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+WORKDIR /app
+COPY --from=upstream /app/vk-turn-proxy /app/vk-turn-proxy
+COPY --from=upstream /app/docker-entrypoint.sh /app/docker-entrypoint.sh
+COPY run.sh /run.sh
+RUN chmod +x /app/docker-entrypoint.sh /app/vk-turn-proxy /run.sh
+
+EXPOSE 56000/udp
+
+CMD ["/run.sh"]
+
+LABEL \
+  io.hass.version=${BUILD_VERSION} \
+  io.hass.type="addon" \
+  io.hass.arch="${BUILD_ARCH}" \
+  org.opencontainers.image.licenses="MIT" \
+  org.opencontainers.image.created=${BUILD_DATE} \
+  org.opencontainers.image.revision=${BUILD_REF} \
+  org.opencontainers.image.version=${BUILD_VERSION}

--- a/vk-turn-proxy/README.md
+++ b/vk-turn-proxy/README.md
@@ -1,0 +1,53 @@
+# VK TURN Proxy
+
+Home Assistant app wrapper for [`cacggghp/vk-turn-proxy`](https://github.com/cacggghp/vk-turn-proxy).
+
+## What this app is for
+
+This app is for **tunneling traffic through TURN servers** used by VK calls.
+
+In practical terms, it is meant for scenarios such as:
+- tunneling **WireGuard** traffic
+- tunneling **VLESS/Xray** traffic
+- forwarding traffic through the upstream `vk-turn-proxy` server flow
+
+This app wraps the **server-side** component and exposes UDP port `56000`.
+
+## What it does
+
+The app accepts incoming traffic on port `56000/udp` and forwards it to a configured backend target.
+
+Typical backend examples:
+- `127.0.0.1:51820` for local WireGuard
+- `192.168.1.10:51820` for remote/local WireGuard on another host
+- a TCP/VLESS-style backend when `vless_mode` is enabled
+
+## Configuration
+
+### `connect_addr`
+Required backend address in the form:
+
+`host:port`
+
+Examples:
+- `127.0.0.1:51820`
+- `192.168.1.10:51820`
+
+### `vless_mode`
+If enabled, the proxy runs in VLESS-oriented TCP forwarding mode.
+Leave disabled for the default UDP/WireGuard-style mode.
+
+## Ports
+
+- `56000/udp` — external proxy port
+
+## Notes
+
+- This app wraps the **server** binary, not the client tools
+- You still need a compatible client side and a valid call-link workflow as described upstream
+- The exact traffic behavior and anti-censorship properties come from the upstream project design
+
+## Upstream project
+
+- Repository: <https://github.com/cacggghp/vk-turn-proxy>
+- Container image: <https://github.com/cacggghp/vk-turn-proxy/pkgs/container/vk-turn-proxy>

--- a/vk-turn-proxy/build.yaml
+++ b/vk-turn-proxy/build.yaml
@@ -1,0 +1,7 @@
+---
+codenotary:
+    signer: "red.avtovo@gmail.com"
+
+build_from:
+    amd64: "ghcr.io/home-assistant/amd64-base-ubuntu:24.04"
+    aarch64: "ghcr.io/home-assistant/aarch64-base-ubuntu:24.04"

--- a/vk-turn-proxy/config.yaml
+++ b/vk-turn-proxy/config.yaml
@@ -1,0 +1,30 @@
+---
+name: VK TURN Proxy
+version: 1.8.2
+slug: vk-turn-proxy
+description: |
+  TURN-based UDP/TCP proxy for tunneling traffic through VK calls.
+
+  Wraps vk-turn-proxy for Home Assistant style deployment. Useful for forwarding
+  WireGuard or VLESS-style traffic through TURN infrastructure.
+options:
+  connect_addr: ""
+  vless_mode: false
+schema:
+  connect_addr: str
+  vless_mode: bool
+init: false
+startup: services
+arch:
+  - aarch64
+  - amd64
+boot: auto
+codenotary: red.avtovo@gmail.com
+image: "ghcr.io/j0rsa/haddon-vk-turn-proxy-{arch}"
+udev: false
+url: https://github.com/j0rsa/home-assistant-apps
+ports:
+  56000/udp: 56000
+ports_description:
+  56000/udp: VK TURN proxy UDP port
+panel_icon: mdi:swap-horizontal-network

--- a/vk-turn-proxy/run.sh
+++ b/vk-turn-proxy/run.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/with-contenv bashio
+set -euo pipefail
+
+CONNECT_ADDR="$(bashio::config 'connect_addr')"
+VLESS_MODE="$(bashio::config 'vless_mode')"
+
+if [[ -z "${CONNECT_ADDR}" ]]; then
+    bashio::log.error "connect_addr is required"
+    exit 1
+fi
+
+bashio::log.info "Starting VK TURN Proxy"
+bashio::log.info "Forwarding to ${CONNECT_ADDR}"
+
+export CONNECT_ADDR
+if [[ "${VLESS_MODE}" == "true" ]]; then
+    bashio::log.info "VLESS mode enabled"
+    export VLESS_MODE="true"
+else
+    export VLESS_MODE="false"
+fi
+
+exec /app/docker-entrypoint.sh

--- a/vk-turn-proxy/translations/en.yaml
+++ b/vk-turn-proxy/translations/en.yaml
@@ -1,0 +1,13 @@
+configuration:
+  connect_addr:
+    name: Backend address
+    description: >-
+      Address of the backend service that vk-turn-proxy should forward traffic to,
+      in host:port format. For example 127.0.0.1:51820 for a local WireGuard
+      instance.
+  vless_mode:
+    name: VLESS mode
+    description: >-
+      Enable TCP/VLESS-style forwarding mode instead of the default UDP-style
+      forwarding used for WireGuard-like traffic. Leave this disabled for the
+      normal UDP tunneling scenario.


### PR DESCRIPTION
Adds a new Home Assistant app wrapping vk-turn-proxy, including docs page, docs index links, and config translations.