### PR TITLE
Fix VK TURN Proxy Dockerfile build

### DIFF
--- a/vk-turn-proxy/Dockerfile
+++ b/vk-turn-proxy/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base-ubuntu:24.04
+ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base-ubuntu:20.04
 ARG UPSTREAM_IMAGE=ghcr.io/cacggghp/vk-turn-proxy:v1.8.2
 
 FROM ${UPSTREAM_IMAGE} AS upstream

--- a/vk-turn-proxy/build.yaml
+++ b/vk-turn-proxy/build.yaml
@@ -3,5 +3,5 @@ codenotary:
     signer: "red.avtovo@gmail.com"
 
 build_from:
-    amd64: "ghcr.io/home-assistant/amd64-base-ubuntu:24.04"
-    aarch64: "ghcr.io/home-assistant/aarch64-base-ubuntu:24.04"
+    amd64: "ghcr.io/home-assistant/amd64-base-ubuntu:20.04"
+    aarch64: "ghcr.io/home-assistant/aarch64-base-ubuntu:20.04"


### PR DESCRIPTION
Fixes the Home Assistant base image tags for vk-turn-proxy so the image resolves correctly and builds successfully. I also validated the image locally by building it against the aarch64 base image.