### PR TITLE
Add blueprint for scene activation automation

### DIFF
--- a/blueprints/scene-autoscript-trigger.yaml
+++ b/blueprints/scene-autoscript-trigger.yaml
@@ -1,0 +1,48 @@
+blueprint:
+  name: Run action when scene activates
+  description: Trigger a script or automation when a specific scene is turned on
+  domain: automation
+  input:
+    watched_scene:
+      name: Scene
+      selector:
+        entity:
+          domain: scene
+    target_action:
+      name: Script or automation to run
+      selector:
+        entity:
+          domain:
+            - script
+            - automation
+
+mode: single
+
+trigger_variables:
+  watched_scene: !input watched_scene
+
+trigger:
+  - platform: event
+    event_type: call_service
+    event_data:
+      domain: scene
+      service: turn_on
+
+condition:
+  - condition: template
+    value_template: >
+      {{ trigger.event.data.service_data.entity_id == watched_scene }}
+
+action:
+  - choose:
+      - conditions: >
+          {{ watched_scene is not none and states((!input target_action).split('.')[0] ~ '.' ~ (!input target_action).split('.')[1]) is not none }}
+        sequence: []
+  - service: >
+      {% if ( !input target_action ).split('.')[0] == 'script' %}
+        script.turn_on
+      {% else %}
+        automation.trigger
+      {% endif %}
+    target:
+      entity_id: !input target_action


### PR DESCRIPTION
This pull request introduces a new automation blueprint for Home Assistant, allowing users to trigger a script or automation whenever a specific scene is activated. The blueprint is designed to be flexible, supporting both scripts and automations as target actions.

**New Blueprint: Scene Activation Trigger**

* Added `scene-autoscript-trigger.yaml`, a blueprint that triggers a user-specified script or automation when a selected scene is turned on.
* Supports selection of both scenes to watch and the target script or automation to run, using Home Assistant's entity selectors.
* Handles both `script.turn_on` and `automation.trigger` services, depending on the selected target action.